### PR TITLE
Add Fastify backend skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,14 @@ This contains everything you need to run your app locally.
 2. Set the `GEMINI_API_KEY` in [.env.local](.env.local) to your Gemini API key
 3. Run the app:
    `npm run dev`
+
+## Backend Server
+
+A Fastify + TypeScript backend is provided in the `server/` folder. To run it:
+
+```bash
+cd server
+npm install
+cp .env.example .env # update values
+npm run dev
+```

--- a/server/.env.example
+++ b/server/.env.example
@@ -1,0 +1,3 @@
+PORT=3000
+DATABASE_URL="postgresql://user:pass@localhost:5432/lenscraft"
+JWT_SECRET="your-secret"

--- a/server/package.json
+++ b/server/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "lenscraft-backend",
+  "version": "1.0.0",
+  "main": "dist/server.js",
+  "scripts": {
+    "dev": "ts-node src/server.ts",
+    "build": "tsc",
+    "start": "node dist/server.js",
+    "prisma": "prisma"
+  },
+  "dependencies": {
+    "@fastify/cors": "^8.2.1",
+    "@fastify/jwt": "^7.1.0",
+    "@prisma/client": "5.14.1",
+    "dotenv": "^16.4.5",
+    "fastify": "^4.26.2",
+    "fastify-helmet": "^10.0.0",
+    "zod": "^3.22.4",
+    "bcryptjs": "^2.4.3"
+  },
+  "devDependencies": {
+    "prisma": "5.14.1",
+    "ts-node": "^10.9.2",
+    "typescript": "^5.4.5"
+  }
+}

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -1,0 +1,34 @@
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+
+generator client {
+  provider = "prisma-client-js"
+}
+
+model User {
+  id       Int    @id @default(autoincrement())
+  username String @unique
+  password String
+  role     String?
+  createdAt DateTime @default(now())
+}
+
+model Order {
+  id        Int      @id @default(autoincrement())
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+}
+
+model Invoice {
+  id        Int      @id @default(autoincrement())
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+}
+
+model Product {
+  id    Int    @id @default(autoincrement())
+  name  String
+  price Float
+}

--- a/server/src/modules/about/routes.ts
+++ b/server/src/modules/about/routes.ts
@@ -1,0 +1,8 @@
+import { FastifyPluginAsync } from 'fastify';
+
+const routes: FastifyPluginAsync = async (fastify) => {
+  fastify.get('/', async () => ({ message: 'about list' }));
+  fastify.post('/', async () => ({ message: 'about create' }));
+};
+
+export default routes;

--- a/server/src/modules/ai-settings/routes.ts
+++ b/server/src/modules/ai-settings/routes.ts
@@ -1,0 +1,8 @@
+import { FastifyPluginAsync } from 'fastify';
+
+const routes: FastifyPluginAsync = async (fastify) => {
+  fastify.get('/', async () => ({ message: 'ai-settings list' }));
+  fastify.post('/', async () => ({ message: 'ai-settings create' }));
+};
+
+export default routes;

--- a/server/src/modules/auth/controller.ts
+++ b/server/src/modules/auth/controller.ts
@@ -1,0 +1,35 @@
+import { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
+import { loginSchema, registerSchema } from './schema';
+import * as service from './service';
+
+export const registerHandler = async (fastify: FastifyInstance) => async (
+  request: FastifyRequest,
+  reply: FastifyReply
+) => {
+  const data = registerSchema.parse(request.body);
+  const user = await service.register(fastify, data.username, data.password);
+  const token = fastify.jwt.sign({ id: user.id });
+  reply.send({ token });
+};
+
+export const loginHandler = async (fastify: FastifyInstance) => async (
+  request: FastifyRequest,
+  reply: FastifyReply
+) => {
+  const data = loginSchema.parse(request.body);
+  const user = await service.login(fastify, data.username, data.password);
+  if (!user) {
+    return reply.status(401).send({ message: 'invalid credentials' });
+  }
+  const token = fastify.jwt.sign({ id: user.id });
+  reply.send({ token });
+};
+
+export const meHandler = async (fastify: FastifyInstance) => async (
+  request: FastifyRequest,
+  reply: FastifyReply
+) => {
+  const userId = (request.user as any).id;
+  const user = await fastify.prisma.user.findUnique({ where: { id: userId } });
+  reply.send({ user });
+};

--- a/server/src/modules/auth/routes.ts
+++ b/server/src/modules/auth/routes.ts
@@ -1,0 +1,10 @@
+import { FastifyPluginAsync } from 'fastify';
+import { registerHandler, loginHandler, meHandler } from './controller';
+
+const authRoutes: FastifyPluginAsync = async (fastify) => {
+  fastify.post('/register', registerHandler(fastify));
+  fastify.post('/login', loginHandler(fastify));
+  fastify.get('/me', { preValidation: [fastify.authenticate] }, meHandler(fastify));
+};
+
+export default authRoutes;

--- a/server/src/modules/auth/schema.ts
+++ b/server/src/modules/auth/schema.ts
@@ -1,0 +1,8 @@
+import { z } from 'zod';
+
+export const registerSchema = z.object({
+  username: z.string().min(3),
+  password: z.string().min(6)
+});
+
+export const loginSchema = registerSchema;

--- a/server/src/modules/auth/service.ts
+++ b/server/src/modules/auth/service.ts
@@ -1,0 +1,16 @@
+import { FastifyInstance } from 'fastify';
+import { hash, compare } from 'bcryptjs';
+
+export const register = async (fastify: FastifyInstance, username: string, password: string) => {
+  const hashed = await hash(password, 10);
+  const user = await fastify.prisma.user.create({ data: { username, password: hashed } });
+  return user;
+};
+
+export const login = async (fastify: FastifyInstance, username: string, password: string) => {
+  const user = await fastify.prisma.user.findUnique({ where: { username } });
+  if (!user) return null;
+  const valid = await compare(password, user.password);
+  if (!valid) return null;
+  return user;
+};

--- a/server/src/modules/backup/routes.ts
+++ b/server/src/modules/backup/routes.ts
@@ -1,0 +1,8 @@
+import { FastifyPluginAsync } from 'fastify';
+
+const routes: FastifyPluginAsync = async (fastify) => {
+  fastify.get('/', async () => ({ message: 'backup list' }));
+  fastify.post('/', async () => ({ message: 'backup create' }));
+};
+
+export default routes;

--- a/server/src/modules/cashbox/routes.ts
+++ b/server/src/modules/cashbox/routes.ts
@@ -1,0 +1,8 @@
+import { FastifyPluginAsync } from 'fastify';
+
+const routes: FastifyPluginAsync = async (fastify) => {
+  fastify.get('/', async () => ({ message: 'cashbox list' }));
+  fastify.post('/', async () => ({ message: 'cashbox create' }));
+};
+
+export default routes;

--- a/server/src/modules/costs/routes.ts
+++ b/server/src/modules/costs/routes.ts
@@ -1,0 +1,8 @@
+import { FastifyPluginAsync } from 'fastify';
+
+const routes: FastifyPluginAsync = async (fastify) => {
+  fastify.get('/', async () => ({ message: 'costs list' }));
+  fastify.post('/', async () => ({ message: 'costs create' }));
+};
+
+export default routes;

--- a/server/src/modules/expenses/routes.ts
+++ b/server/src/modules/expenses/routes.ts
@@ -1,0 +1,8 @@
+import { FastifyPluginAsync } from 'fastify';
+
+const routes: FastifyPluginAsync = async (fastify) => {
+  fastify.get('/', async () => ({ message: 'expenses list' }));
+  fastify.post('/', async () => ({ message: 'expenses create' }));
+};
+
+export default routes;

--- a/server/src/modules/invoices/routes.ts
+++ b/server/src/modules/invoices/routes.ts
@@ -1,0 +1,8 @@
+import { FastifyPluginAsync } from 'fastify';
+
+const routes: FastifyPluginAsync = async (fastify) => {
+  fastify.get('/', async () => ({ message: 'invoices list' }));
+  fastify.post('/', async () => ({ message: 'invoices create' }));
+};
+
+export default routes;

--- a/server/src/modules/orders/routes.ts
+++ b/server/src/modules/orders/routes.ts
@@ -1,0 +1,8 @@
+import { FastifyPluginAsync } from 'fastify';
+
+const routes: FastifyPluginAsync = async (fastify) => {
+  fastify.get('/', async () => ({ message: 'orders list' }));
+  fastify.post('/', async () => ({ message: 'orders create' }));
+};
+
+export default routes;

--- a/server/src/modules/products/routes.ts
+++ b/server/src/modules/products/routes.ts
@@ -1,0 +1,8 @@
+import { FastifyPluginAsync } from 'fastify';
+
+const routes: FastifyPluginAsync = async (fastify) => {
+  fastify.get('/', async () => ({ message: 'products list' }));
+  fastify.post('/', async () => ({ message: 'products create' }));
+};
+
+export default routes;

--- a/server/src/modules/transactions/routes.ts
+++ b/server/src/modules/transactions/routes.ts
@@ -1,0 +1,8 @@
+import { FastifyPluginAsync } from 'fastify';
+
+const routes: FastifyPluginAsync = async (fastify) => {
+  fastify.get('/', async () => ({ message: 'transactions list' }));
+  fastify.post('/', async () => ({ message: 'transactions create' }));
+};
+
+export default routes;

--- a/server/src/plugins/authenticate.ts
+++ b/server/src/plugins/authenticate.ts
@@ -1,0 +1,19 @@
+import { FastifyPluginAsync } from 'fastify';
+
+const authenticate: FastifyPluginAsync = async (fastify) => {
+  fastify.decorate('authenticate', async (request) => {
+    try {
+      await request.jwtVerify();
+    } catch (err) {
+      throw fastify.httpErrors.unauthorized();
+    }
+  });
+};
+
+export default authenticate;
+
+declare module 'fastify' {
+  interface FastifyInstance {
+    authenticate: any;
+  }
+}

--- a/server/src/plugins/prisma.ts
+++ b/server/src/plugins/prisma.ts
@@ -1,0 +1,17 @@
+import fp from 'fastify-plugin';
+import { PrismaClient } from '@prisma/client';
+
+export default fp(async (fastify, _opts) => {
+  const prisma = new PrismaClient();
+  await prisma.$connect();
+  fastify.decorate('prisma', prisma);
+  fastify.addHook('onClose', async () => {
+    await prisma.$disconnect();
+  });
+});
+
+declare module 'fastify' {
+  interface FastifyInstance {
+    prisma: PrismaClient;
+  }
+}

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -1,0 +1,52 @@
+import Fastify from 'fastify';
+import cors from '@fastify/cors';
+import fastifyJwt from '@fastify/jwt';
+import helmet from 'fastify-helmet';
+import dotenv from 'dotenv';
+import prismaPlugin from './plugins/prisma';
+import authenticatePlugin from './plugins/authenticate';
+import authRoutes from './modules/auth/routes';
+import ordersRoutes from './modules/orders/routes';
+import invoicesRoutes from './modules/invoices/routes';
+import productsRoutes from './modules/products/routes';
+import costsRoutes from './modules/costs/routes';
+import expensesRoutes from './modules/expenses/routes';
+import transactionsRoutes from './modules/transactions/routes';
+import cashboxRoutes from './modules/cashbox/routes';
+import aiSettingsRoutes from './modules/ai-settings/routes';
+import backupRoutes from './modules/backup/routes';
+import aboutRoutes from './modules/about/routes';
+
+dotenv.config();
+
+const server = Fastify({ logger: true });
+
+server.register(cors);
+server.register(helmet);
+server.register(fastifyJwt, { secret: process.env.JWT_SECRET! });
+server.register(prismaPlugin);
+server.register(authenticatePlugin);
+
+server.register(authRoutes, { prefix: '/auth' });
+server.register(ordersRoutes, { prefix: '/orders' });
+server.register(invoicesRoutes, { prefix: '/invoices' });
+server.register(productsRoutes, { prefix: '/products' });
+server.register(costsRoutes, { prefix: '/costs' });
+server.register(expensesRoutes, { prefix: '/expenses' });
+server.register(transactionsRoutes, { prefix: '/transactions' });
+server.register(cashboxRoutes, { prefix: '/cashbox' });
+server.register(aiSettingsRoutes, { prefix: '/ai/settings' });
+server.register(backupRoutes, { prefix: '/backup' });
+server.register(aboutRoutes, { prefix: '/about' });
+
+const start = async () => {
+  try {
+    await server.listen({ port: Number(process.env.PORT) || 3000, host: '0.0.0.0' });
+    console.log('Server running');
+  } catch (err) {
+    server.log.error(err);
+    process.exit(1);
+  }
+};
+
+start();

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "CommonJS",
+    "rootDir": "src",
+    "outDir": "dist",
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- add `server` folder with a Fastify + TypeScript backend
- provide Prisma schema and example env values
- stub API routes for auth and business modules
- document backend usage in README

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_68780da79108833081ea2f37b26ed232